### PR TITLE
feat(nvim): add erlangls and fix Neovim deprecations

### DIFF
--- a/lua/foufa/lazy.lua
+++ b/lua/foufa/lazy.lua
@@ -1,5 +1,5 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
 	vim.fn.system({
 		"git",
 		"clone",

--- a/lua/foufa/plugins/lsp/lspconfig.lua
+++ b/lua/foufa/plugins/lsp/lspconfig.lua
@@ -47,10 +47,14 @@ return {
 			keymap.set("n", "<leader>d", vim.diagnostic.open_float, opts) -- show diagnostics for line
 
 			opts.desc = "Go to previous diagnostic"
-			keymap.set("n", "[d", vim.diagnostic.goto_prev, opts) -- jump to previous diagnostic in buffer
+			keymap.set("n", "[d", function()
+				vim.diagnostic.jump({ count = -1 })
+			end, opts) -- jump to previous diagnostic in buffer
 
 			opts.desc = "Go to next diagnostic"
-			keymap.set("n", "]d", vim.diagnostic.goto_next, opts) -- jump to next diagnostic in buffer
+			keymap.set("n", "]d", function()
+				vim.diagnostic.jump({ count = 1 })
+			end, opts) -- jump to next diagnostic in buffer
 
 			opts.desc = "Show documentation for what is under cursor"
 			keymap.set("n", "K", vim.lsp.buf.hover, opts) -- show documentation for what is under cursor
@@ -184,15 +188,21 @@ return {
 
 		lspconfig["gleam"].setup({})
 		lspconfig["gopls"].setup({})
+		-- configure Erlang server
+		lspconfig["erlangls"].setup({
+			capabilities = capabilities,
+			on_attach = on_attach,
+		})
 		lspconfig["lexical"].setup({
 			cmd = { "/home/anesfoufa/.local/share/nvim/mason/packages/lexical/libexec/lexical/bin/start_lexical.sh" },
 			root_dir = function(fname)
-				return lspconfig.util.root_pattern("mix.exs", ".git")(fname) or vim.loop.cwd()
+				return lspconfig.util.root_pattern("mix.exs", ".git")(fname) or (vim.uv or vim.loop).cwd()
 			end,
 			filetypes = { "elixir", "eelixir", "heex" },
 			-- optional settings
 			settings = {},
 		})
 		lspconfig["bashls"].setup({})
+		lspconfig["erlangls"].setup({})
 	end,
 }

--- a/lua/foufa/plugins/lsp/mason.lua
+++ b/lua/foufa/plugins/lsp/mason.lua
@@ -40,6 +40,7 @@ return {
 				"rust_analyzer",
 				"bashls",
 				"lexical",
+				"erlangls",
 			},
 			-- auto-install configured servers (with lspconfig)
 			automatic_installation = true, -- not the same as ensure_installed

--- a/lua/foufa/plugins/lsp/none-ls.lua
+++ b/lua/foufa/plugins/lsp/none-ls.lua
@@ -64,7 +64,7 @@ return {
 			},
 			-- configure format on save
 			on_attach = function(current_client, bufnr)
-				if current_client.supports_method("textDocument/formatting") then
+				if current_client:supports_method("textDocument/formatting") then
 					vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
 					vim.api.nvim_create_autocmd("BufWritePre", {
 						group = augroup,

--- a/lua/foufa/plugins/nvim-tree.lua
+++ b/lua/foufa/plugins/nvim-tree.lua
@@ -1,67 +1,57 @@
 return {
 	"nvim-tree/nvim-tree.lua",
 	dependencies = { "nvim-tree/nvim-web-devicons" },
-	config = function()
-		local nvimtree = require("nvim-tree")
-
-		-- recommended settings from nvim-tree documentation
-		-- vim.g.loaded_netrw = 0
-		-- vim.g.loaded_netrwPlugin = 0
-
+	-- lazy-load on command or keypress to avoid loading at startup
+	cmd = { "NvimTreeToggle", "NvimTreeOpen", "NvimTreeClose", "NvimTreeFindFileToggle", "NvimTreeRefresh", "NvimTreeCollapse", "NvimTreeFocus" },
+	keys = {
+		{ "<leader>ee", "<cmd>NvimTreeToggle<CR>", desc = "Toggle file explorer" },
+		{ "<leader>ef", "<cmd>NvimTreeFindFileToggle<CR>", desc = "Toggle explorer on current file" },
+		{ "<leader>ec", "<cmd>NvimTreeCollapse<CR>", desc = "Collapse file explorer" },
+		{ "<leader>er", "<cmd>NvimTreeRefresh<CR>", desc = "Refresh file explorer" },
+	},
+	init = function()
 		-- change color for arrows in tree to light blue
 		vim.cmd([[ highlight NvimTreeFolderArrowClosed guifg=#3FC5FF ]])
 		vim.cmd([[ highlight NvimTreeFolderArrowOpen guifg=#3FC5FF ]])
-
-		-- configure nvim-tree
-		nvimtree.setup({
-			view = {
-				relativenumber = true,
-				adaptive_size = false,
-				preserve_window_proportions = true,
+	end,
+	opts = {
+		view = {
+			relativenumber = true,
+			adaptive_size = false,
+			preserve_window_proportions = true,
+		},
+		-- change folder arrow icons
+		renderer = {
+			indent_markers = {
+				enable = true,
 			},
-			-- change folder arrow icons
-			renderer = {
-				indent_markers = {
-					enable = true,
-				},
-				icons = {
-					glyphs = {
-						folder = {
-							arrow_closed = "", -- arrow when folder is closed
-							arrow_open = "", -- arrow when folder is open
-						},
+			icons = {
+				glyphs = {
+					folder = {
+						arrow_closed = "", -- arrow when folder is closed
+						arrow_open = "", -- arrow when folder is open
 					},
 				},
 			},
-			-- disable window_picker for
-			-- explorer to work well with
-			-- window splits
-			actions = {
-				open_file = {
-					window_picker = {
-						enable = false,
-					},
+		},
+		-- disable window_picker for
+		-- explorer to work well with
+		-- window splits
+		actions = {
+			open_file = {
+				window_picker = {
+					enable = false,
 				},
 			},
-			filters = {
-				custom = { ".DS_Store" },
-			},
-			git = {
-				ignore = false,
-			},
-		})
-
-		-- set keymaps
-		local keymap = vim.keymap -- for conciseness
-
-		keymap.set("n", "<leader>ee", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle file explorer" }) -- toggle file explorer
-		keymap.set(
-			"n",
-			"<leader>ef",
-			"<cmd>NvimTreeFindFileToggle<CR>",
-			{ desc = "Toggle file explorer on current file" }
-		) -- toggle file explorer on current file
-		keymap.set("n", "<leader>ec", "<cmd>NvimTreeCollapse<CR>", { desc = "Collapse file explorer" }) -- collapse file explorer
-		keymap.set("n", "<leader>er", "<cmd>NvimTreeRefresh<CR>", { desc = "Refresh file explorer" }) -- refresh file explorer
+		},
+		filters = {
+			custom = { ".DS_Store" },
+		},
+		git = {
+			ignore = false,
+		},
+	},
+	config = function(_, opts)
+		require("nvim-tree").setup(opts)
 	end,
 }

--- a/lua/foufa/plugins/sclametals.lua
+++ b/lua/foufa/plugins/sclametals.lua
@@ -97,11 +97,11 @@ return {
 			map("n", "<leader>d", vim.diagnostic.setloclist)
 
 			map("n", "[c", function()
-				vim.diagnostic.goto_prev({ wrap = false })
+				vim.diagnostic.jump({ count = -1, wrap = false })
 			end)
 
 			map("n", "]c", function()
-				vim.diagnostic.goto_next({ wrap = false })
+				vim.diagnostic.jump({ count = 1, wrap = false })
 			end)
 
 			-- Example mappings for usage with nvim-dap. If you don't use that, you can


### PR DESCRIPTION
- Add erlang_ls LSP setup and Mason ensure_installed\n- Replace deprecated vim.loop with (vim.uv or vim.loop) in lazy.lua and lspconfig.lua\n- Use client:supports_method in none-ls on_attach\n- Switch diagnostic navigation to vim.diagnostic.jump in lspconfig and sclametals\n- Refactor nvim-tree config to lazy-load via cmd/keys and opts\n\nHealth: :checkhealth vim.deprecated shows no config-side warnings; plugin-side noise from nvim-tree avoided by lazy-loading.